### PR TITLE
fix: clear started_config_hash and skip backfill during session reset

### DIFF
--- a/cmd/gc/session_beads.go
+++ b/cmd/gc/session_beads.go
@@ -247,7 +247,11 @@ func syncSessionBeads(
 			queueMeta("wake_mode", tp.WakeMode)
 		}
 		// Backfill session_key for beads created before this fix.
-		if b.Metadata["session_key"] == "" && tp.ResolvedProvider != nil && tp.ResolvedProvider.SessionIDFlag != "" {
+		// Skip when continuation_reset_pending is set — the key was
+		// intentionally cleared (e.g. by gc handoff) and the next wake
+		// should generate a fresh key with firstStart=true semantics.
+		if b.Metadata["session_key"] == "" && b.Metadata["continuation_reset_pending"] == "" &&
+			tp.ResolvedProvider != nil && tp.ResolvedProvider.SessionIDFlag != "" {
 			if key, err := session.GenerateSessionKey(); err == nil {
 				queueMeta("session_key", key)
 			}

--- a/cmd/gc/session_reconciler.go
+++ b/cmd/gc/session_reconciler.go
@@ -271,9 +271,11 @@ func reconcileSessionBeads(
 				if session.Metadata["session_key"] != "" {
 					_ = store.SetMetadataBatch(session.ID, map[string]string{
 						"session_key":                "",
+						"started_config_hash":        "",
 						"continuation_reset_pending": "true",
 					})
 					session.Metadata["session_key"] = ""
+					session.Metadata["started_config_hash"] = ""
 					session.Metadata["continuation_reset_pending"] = "true"
 				}
 				if err := sp.Stop(name); err != nil {


### PR DESCRIPTION
## Summary
- Clears `started_config_hash` alongside `session_key` on restart-requested so handoff starts completely fresh
- Skips backfill during reset to avoid stale state leaking into new sessions

## Test plan
- [ ] `make install` and verify handoff creates a clean session
- [ ] Confirm no stale config hash persists after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)