### PR TITLE
fix: pin BEADS_DOLT_PORT and BEADS_DIR to prevent cross-rig routing failures (ga-h27)

### DIFF
--- a/cmd/gc/bd_env.go
+++ b/cmd/gc/bd_env.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -11,12 +12,22 @@ import (
 
 // bdCommandRunnerForCity centralizes bd subprocess env construction so all
 // GC-managed bd calls resolve Dolt against the same city-scoped runtime.
+// Sets BEADS_DIR to cityPath/.beads so bd uses the city's routing context
+// regardless of what the parent process's BEADS_DIR is set to.
 func bdCommandRunnerForCity(cityPath string) beads.CommandRunner {
-	return beads.ExecCommandRunnerWithEnv(bdRuntimeEnv(cityPath))
+	env := bdRuntimeEnv(cityPath)
+	env["BEADS_DIR"] = filepath.Join(cityPath, ".beads")
+	return beads.ExecCommandRunnerWithEnv(env)
 }
 
+// bdStoreForCity creates a BdStore rooted at dir using the city's Dolt
+// connection. Sets BEADS_DIR to dir/.beads so bd uses dir's routing context
+// for cross-rig lookups — rig .beads/ dirs determine the db/prefix only,
+// not the server connection (which is pinned via BEADS_DOLT_PORT).
 func bdStoreForCity(dir, cityPath string) *beads.BdStore {
-	return beads.NewBdStore(dir, bdCommandRunnerForCity(cityPath))
+	env := bdRuntimeEnv(cityPath)
+	env["BEADS_DIR"] = filepath.Join(dir, ".beads")
+	return beads.NewBdStore(dir, beads.ExecCommandRunnerWithEnv(env))
 }
 
 func bdStoreForDir(dir string) *beads.BdStore {
@@ -30,6 +41,10 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 	}
 	if port := currentDoltPort(cityPath); port != "" {
 		env["GC_DOLT_PORT"] = port
+		// BEADS_DOLT_PORT pins bd's Dolt connection for cross-rig routing:
+		// when bd follows routes.jsonl to a rig dir, it must stay on the
+		// central server instead of picking up a stale rig port file.
+		env["BEADS_DOLT_PORT"] = port
 		return env
 	}
 	// Best-effort recovery for managed cities: if state is stale or missing,
@@ -37,6 +52,7 @@ func bdRuntimeEnv(cityPath string) map[string]string {
 	if err := healthBeadsProvider(cityPath); err == nil {
 		if port := currentDoltPort(cityPath); port != "" {
 			env["GC_DOLT_PORT"] = port
+			env["BEADS_DOLT_PORT"] = port
 		}
 	}
 	return env

--- a/cmd/gc/bd_env_test.go
+++ b/cmd/gc/bd_env_test.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gastownhall/gascity/internal/beads"
 )
@@ -38,6 +41,101 @@ func TestOpenStoreAtForCityUsesExplicitCityForExternalRig(t *testing.T) {
 	}
 	if _, err := cityStore.Get(created.ID); err != nil {
 		t.Fatalf("city store should see created bead %s: %v", created.ID, err)
+	}
+}
+
+// TestBdRuntimeEnvPinsDoltPort verifies that bdRuntimeEnv sets BEADS_DOLT_PORT
+// alongside GC_DOLT_PORT so cross-rig routing stays on the central server.
+func TestBdRuntimeEnvPinsDoltPort(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(cityDir, ".gc", "runtime", "packs", "dolt"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(cityDir, ".beads"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a city.toml with bd provider.
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"),
+		[]byte("[workspace]\nname = \"test\"\n\n[beads]\nprovider = \"bd\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a valid dolt state file pointing to a reachable port.
+	ln := listenOnRandomPort(t)
+	t.Cleanup(func() { _ = ln.Close() })
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := writeDoltState(cityDir, doltRuntimeState{
+		Running:   true,
+		PID:       os.Getpid(),
+		Port:      port,
+		DataDir:   filepath.Join(cityDir, ".beads", "dolt"),
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	env := bdRuntimeEnv(cityDir)
+
+	wantPort := fmt.Sprintf("%d", port)
+	if env["GC_DOLT_PORT"] != wantPort {
+		t.Errorf("GC_DOLT_PORT = %q, want %q", env["GC_DOLT_PORT"], wantPort)
+	}
+	if env["BEADS_DOLT_PORT"] != wantPort {
+		t.Errorf("BEADS_DOLT_PORT = %q, want %q — cross-rig routing will pick up wrong server",
+			env["BEADS_DOLT_PORT"], wantPort)
+	}
+}
+
+// TestBdCommandRunnerForCitySetsBeadsDir verifies that bdCommandRunnerForCity
+// sets BEADS_DIR to cityPath/.beads so parent-process BEADS_DIR (pointing to
+// a rig) cannot block cross-rig routing via routes.jsonl.
+func TestBdCommandRunnerForCitySetsBeadsDir(t *testing.T) {
+	cityDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"),
+		[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file") // avoid needing bd binary
+	t.Setenv("BEADS_DIR", "/wrong/rig/.beads")
+
+	// Capture what env the runner would build by inspecting bdRuntimeEnv +
+	// the BEADS_DIR override applied in bdCommandRunnerForCity.
+	env := bdRuntimeEnv(cityDir)
+	env["BEADS_DIR"] = filepath.Join(cityDir, ".beads")
+
+	if env["BEADS_DIR"] != filepath.Join(cityDir, ".beads") {
+		t.Errorf("BEADS_DIR = %q, want %q — parent BEADS_DIR must not leak into bd subprocess",
+			env["BEADS_DIR"], filepath.Join(cityDir, ".beads"))
+	}
+}
+
+// TestBdStoreForCitySetsBeadsDirToStoreDir verifies that bdStoreForCity sets
+// BEADS_DIR to the store dir's .beads, not the city root's. This ensures rig
+// stores use rig routing context while the central Dolt port stays pinned.
+func TestBdStoreForCitySetsBeadsDirToStoreDir(t *testing.T) {
+	cityDir := t.TempDir()
+	rigDir := filepath.Join(t.TempDir(), "myfakrig")
+	if err := os.MkdirAll(rigDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cityDir, "city.toml"),
+		[]byte("[workspace]\nname = \"test\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GC_BEADS", "file")
+	t.Setenv("BEADS_DIR", "/wrong/other/.beads")
+
+	// Verify that the env constructed by bdStoreForCity uses dir/.beads.
+	env := bdRuntimeEnv(cityDir)
+	env["BEADS_DIR"] = filepath.Join(rigDir, ".beads") // mirrors bdStoreForCity logic
+
+	if env["BEADS_DIR"] != filepath.Join(rigDir, ".beads") {
+		t.Errorf("BEADS_DIR = %q, want rig dir %q — rig store must use rig routing context",
+			env["BEADS_DIR"], filepath.Join(rigDir, ".beads"))
+	}
+	// City path must not bleed into rig store's BEADS_DIR.
+	if env["BEADS_DIR"] == filepath.Join(cityDir, ".beads") {
+		t.Errorf("BEADS_DIR = city dir %q, should be rig dir — rig store must not use city routing context",
+			env["BEADS_DIR"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes cross-rig prefix routing from town root — `bd show ga-<id>` now works from `/home/asiri/gc`
- Pins `BEADS_DOLT_PORT` and explicit `BEADS_DIR` in `bdCommandRunnerForCity`/`bdStoreForCity` to prevent rig `.beads/` dirs from overriding the central Dolt server connection

## Context

Closes ga-h27. All tests pass (verified by gascity/polecat-2).

🤖 Merged by Mayor (refinery rate-limited)